### PR TITLE
Develop/validation

### DIFF
--- a/src/main/java/org/helm/monomerservice/IValidation.java
+++ b/src/main/java/org/helm/monomerservice/IValidation.java
@@ -1,0 +1,13 @@
+package org.helm.monomerservice;
+
+import org.helm.notation2.Attachment;
+import java.util.List;
+
+public interface IValidation {
+
+    int checkRule(Rule rule);
+
+    int checkMonomer(LWMonomer monomer);
+
+    boolean checkRGroup(String smiles, List<Attachment> attachment);
+}

--- a/src/main/java/org/helm/monomerservice/MonomerLibraryMongoDB.java
+++ b/src/main/java/org/helm/monomerservice/MonomerLibraryMongoDB.java
@@ -52,6 +52,9 @@ public class MonomerLibraryMongoDB implements IMonomerLibrary {
 
 	private static final Logger LOG = LoggerFactory.getLogger(MonomerLibraryMongoDB.class);
 
+	private final Validation validation = new Validation(LOG);
+
+
 	@Override
 	public int deleteMonomer(String polymerType, String symbol) throws Exception {
 		MongoClient mongoClient = new MongoClient(LibraryManager.getHostname(),
@@ -222,8 +225,8 @@ public class MonomerLibraryMongoDB implements IMonomerLibrary {
 	public int insertMonomer(LWMonomer monomer) throws Exception {
 		
 		//check Monomer
-				if(checkMonomer(monomer) != 0) {
-					return checkMonomer(monomer);
+				if(validation.checkMonomer(monomer) != 0) {
+					return validation.checkMonomer(monomer);
 				}		
 		
 		MongoClient mongoClient = new MongoClient(LibraryManager.getHostname(),
@@ -283,8 +286,8 @@ public class MonomerLibraryMongoDB implements IMonomerLibrary {
 	public int updateMonomer(String polymerType, String symbol, LWMonomer monomer) throws Exception {
 		
 		//check Monomer
-		if(checkMonomer(monomer) != 0) {
-			return checkMonomer(monomer);
+		if(validation.checkMonomer(monomer) != 0) {
+			return validation.checkMonomer(monomer);
 		}
 		
 		// return -3000 if monomer is not already registered
@@ -339,110 +342,6 @@ public class MonomerLibraryMongoDB implements IMonomerLibrary {
 			LOG.info("Closed database.");
 		}
 	}
-	
-private int checkMonomer(LWMonomer monomer) {
-		
-		//chekc if Molfile exists
-		if(monomer.getMolfile().isEmpty() || monomer.getMolfile() == null) {
-			LOG.info("Monomer has no Molfile");
-			return -5100;
-		}
-		//check if SMILES exists
-		/*if(monomer.getSmiles().isEmpty()) {
-			LOG.info("Monomer has no SMILES");
-			try {
-				 String smiles = SMILES.convertMolToSMILESWithAtomMapping(monomer.getMolfile(), monomer.getRgroups());
-				 monomer.setSmiles(smiles);
-				 LOG.info("Generate SMILES form Molfile");
-			} catch (Exception e) {
-				LOG.info("SMILES could not be generated from Molfile");
-				return -5200;
-			}
-		}*/
-		
-		//generate Smiles from Molfile
-		try {
-			String smiles = SMILES.convertMolToSMILESWithAtomMapping(monomer.getMolfile(), monomer.getRgroups());
-			//smiles = Chemistry.getInstance().getManipulator().convertExtendedSmiles(smiles);
-			smiles = smiles.replaceAll("\\s+", "");
-			monomer.setSmiles(smiles);
-			LOG.info("Generate SMILES form Molfile: " + smiles);
-		} catch (Exception e) {
-			LOG.info("SMILES could not be generated from Molfile");
-			return -5200;
-		}
-		
-		//check R-group
-		if(!checkRGroup(monomer.getSmiles(), monomer.getRgroups())) {
-			LOG.info("Monomer has wrong R-Groups");
-			return -5300;
-		}
-		
-		//check if Molfile and SMILES match
-		/*try {
-			String smilesMolfile = SMILES.convertMolToSMILESWithAtomMapping(monomer.getMolfile(), monomer.getRgroups());
-			String smilesMolfileUnique = Chemistry.getInstance().getManipulator().canonicalize(smilesMolfile);
-			String smilesUnique = Chemistry.getInstance().getManipulator().canonicalize(monomer.getSmiles());
-			if(!smilesMolfileUnique.equals(smilesUnique)) {
-				LOG.info("Smiles and Molfile do not equal");
-				LOG.info(SMILES.convertMolToSMILESWithAtomMapping(monomer.getMolfile(), monomer.getRgroups()));
-				LOG.info(monomer.getSmiles());
-				return -5400;
-			}
-		} catch (Exception e) {
-			LOG.info("SMILES could not be generated from Molfile");
-			return -5200;
-		}*/
-		
-		if(monomer.getName().isEmpty() || monomer.getName() == null) {
-			LOG.info("Monomer has no Name");
-			return -6000;
-		}
-		if(monomer.getPolymerType().isEmpty() || monomer.getPolymerType() == null) {
-			LOG.info("Monomer has no Polymertype");
-			return -6100;
-		}
-		if(monomer.getSymbol().isEmpty() || monomer.getSymbol() == null) {
-			LOG.info("Monomer has no Symbol");
-			return -6200;
-		}
-		if(monomer.getMonomerType().isEmpty() || monomer.getMonomerType() == null) {
-			LOG.info("Monomer has no Monomertype");
-			return -6300;
-		}
-		if(monomer.getNaturalAnalog().isEmpty() || monomer.getNaturalAnalog() == null) {
-			LOG.info("Monomer has no Natural Analog");
-			return -6400;
-		}
-		if(monomer.getCreateDate().isEmpty() || monomer.getCreateDate() == null) {
-			Date date = new Date();
-			monomer.setCreateDate(date.toString());
-			LOG.info("Monomer has no CreateDate: current date is used");
-		}
-		if(monomer.getAuthor().isEmpty() || monomer.getAuthor() == null) {
-			LOG.info("Monomer has no Author: Author is set to 'unknownAuthor'");
-			monomer.setAuthor("unknownAuthor");
-		}
-		return 0;
-	}
-	
-	private boolean checkRGroup(String smiles, List<Attachment> attachment) {
-		int numberGivenAttachment = attachment.size();
-		int numberAttachmentInSmiles = 0;
-		
-		Pattern pattern = Pattern.compile("\\[\\*:([1-9]\\d*)\\]|\\[\\w+:([1-9]\\d*)\\]");
-		Matcher matcher = pattern.matcher(smiles);
-		
-		while(matcher.find()) {
-			numberAttachmentInSmiles++;
-		}
-		
-		if(numberAttachmentInSmiles == numberGivenAttachment)
-			return true;
-		else
-			return false;
-	}
-	
 
 	@Override
 	public int getTotalCount() throws Exception {

--- a/src/main/java/org/helm/monomerservice/RuleLibraryMongoDB.java
+++ b/src/main/java/org/helm/monomerservice/RuleLibraryMongoDB.java
@@ -39,6 +39,10 @@ public class RuleLibraryMongoDB implements IRuleLibrary {
 	
 	private static final Logger LOG = LoggerFactory.getLogger(MonomerLibraryMongoDB.class);
 
+	private final Validation validation = new Validation(LOG);
+
+
+
 	@Override
 	public int deleteRule(int id) throws Exception {
 		MongoClient mongoClient = new MongoClient(LibraryManager.getHostname(),
@@ -125,8 +129,8 @@ public class RuleLibraryMongoDB implements IRuleLibrary {
 	public int insertOrUpdateRule(Rule rule) throws Exception {
 		
 		//Check rule
-		if(checkRule(rule) != 0) {
-			return checkRule(rule);
+		if(validation.checkRule(rule) != 0) {
+			return validation.checkRule(rule);
 		}
 		
 		JsonConverter converter = new JsonConverter();
@@ -193,36 +197,6 @@ public class RuleLibraryMongoDB implements IRuleLibrary {
 			mongoClient.close();
 			LOG.info("Closed database.");
 		}
-	}
-	
-	private int checkRule(Rule rule) {
-		if(rule.getScript() == null || rule.getScript().isEmpty()) {
-			LOG.info("Rule has no Script");
-			LOG.info("LOLOLOL");
-			return -1000;
-		}
-		
-		if(rule.getScript() == null || rule.getCategory().isEmpty()) {
-			LOG.info("Rule has no category");
-			return -2000;
-		}
-		
-		if(rule.getId() == null || rule.getId().toString().isEmpty()) {
-			LOG.info("Rule has no ID");
-			return -3000;
-		}
-		
-		if(rule.getAuthor() == null || rule.getAuthor().isEmpty()) {
-			rule.setAuthor("unknownAuthor");
-			LOG.info("Rule has no Author; Author is set to 'unkownAuthor'");
-		}
-		
-		if(rule.getDescription() == null || rule.getDescription().isEmpty()) {
-			rule.setDescription("no description");
-			LOG.info("Rule has no description; Description is set to 'no description'");
-		}
-		
-		return 0;
 	}
 
 }

--- a/src/main/java/org/helm/monomerservice/RuleLibrarySQLite.java
+++ b/src/main/java/org/helm/monomerservice/RuleLibrarySQLite.java
@@ -29,6 +29,7 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.ArrayList;
 
+import com.sun.javafx.tools.packager.Log;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +46,9 @@ public class RuleLibrarySQLite implements IRuleLibrary {
 	private static String forname = "org.sqlite.JDBC";
 	private static String connection = "jdbc:sqlite:"
 			+ MonomerLibrarySQLite.class.getResource("resources/MonomerLib2.0.db").toString();
+
+	private final Validation validation = new Validation(LOG);
+
 
 	public int deleteRule(int id) throws Exception {
 		Connection c = null;
@@ -161,8 +165,8 @@ public class RuleLibrarySQLite implements IRuleLibrary {
 			c = getConnection();
 
 			// Check rule
-			if (checkRule(rule) != 0) {
-				return checkRule(rule);
+			if (validation.checkRule(rule) != 0) {
+				return validation.checkRule(rule);
 			}
 
 			// check if rule already exists
@@ -229,35 +233,6 @@ public class RuleLibrarySQLite implements IRuleLibrary {
 		} finally {
 			c.close();
 			LOG.info("Closed database ..");
-		}
-
-		return 0;
-	}
-
-	private int checkRule(Rule rule) {
-		if (rule.getScript() == null || rule.getScript().isEmpty()) {
-			LOG.info("Rule has no Script");
-			return -1000;
-		}
-
-		if (rule.getScript() == null || rule.getCategory().isEmpty()) {
-			LOG.info("Rule has no category");
-			return -2000;
-		}
-
-		if (rule.getId() == null || rule.getId().toString().isEmpty()) {
-			LOG.info("Rule has no ID");
-			return -3000;
-		}
-
-		if (rule.getAuthor() == null || rule.getAuthor().isEmpty()) {
-			rule.setAuthor("unknownAuthor");
-			LOG.info("Rule has no Author; Author is set to 'unkownAuthor'");
-		}
-
-		if (rule.getDescription() == null || rule.getDescription().isEmpty()) {
-			rule.setDescription("no description");
-			LOG.info("Rule has no description; Description is set to 'no description'");
 		}
 
 		return 0;

--- a/src/main/java/org/helm/monomerservice/Validation.java
+++ b/src/main/java/org/helm/monomerservice/Validation.java
@@ -1,0 +1,154 @@
+package org.helm.monomerservice;
+
+import org.helm.notation2.Attachment;
+import org.helm.notation2.tools.SMILES;
+
+import java.util.Date;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Validation implements IValidation {
+    Logger Log;
+
+    public Validation(Logger log) {
+        Log = log;
+    }
+
+
+    @Override
+    public int checkMonomer(LWMonomer monomer) {
+        //chekc if Molfile exists
+        if(monomer.getMolfile().isEmpty() || monomer.getMolfile() == null) {
+            Log.info("Monomer has no Molfile");
+            return -5100;
+        }
+        //check if SMILES exists
+		/*if(monomer.getSmiles().isEmpty()) {
+			LOG.info("Monomer has no SMILES");
+			try {
+				 String smiles = SMILES.convertMolToSMILESWithAtomMapping(monomer.getMolfile(), monomer.getRgroups());
+				 monomer.setSmiles(smiles);
+				 LOG.info("Generate SMILES form Molfile");
+			} catch (Exception e) {
+				LOG.info("SMILES could not be generated from Molfile");
+				return -5200;
+			}
+		}*/
+
+        //generate Smiles from Molfile
+        try {
+            String smiles = SMILES.convertMolToSMILESWithAtomMapping(monomer.getMolfile(), monomer.getRgroups());
+            //smiles = Chemistry.getInstance().getManipulator().convertExtendedSmiles(smiles);
+            smiles = smiles.replaceAll("\\s+", "");
+            monomer.setSmiles(smiles);
+            Log.info("Generate SMILES form Molfile: " + smiles);
+        } catch (Exception e) {
+            Log.info("SMILES could not be generated from Molfile");
+            return -5200;
+        }
+
+        //check R-group
+        if(!checkRGroup(monomer.getSmiles(), monomer.getRgroups())) {
+            Log.info("Monomer has wrong R-Groups");
+            return -5300;
+        }
+
+        //check if Molfile and SMILES match
+		/*try {
+			String smilesMolfile = SMILES.convertMolToSMILESWithAtomMapping(monomer.getMolfile(), monomer.getRgroups());
+			String smilesMolfileUnique = Chemistry.getInstance().getManipulator().canonicalize(smilesMolfile);
+			String smilesUnique = Chemistry.getInstance().getManipulator().canonicalize(monomer.getSmiles());
+			if(!smilesMolfileUnique.equals(smilesUnique)) {
+				LOG.info("Smiles and Molfile do not equal");
+				LOG.info(SMILES.convertMolToSMILESWithAtomMapping(monomer.getMolfile(), monomer.getRgroups()));
+				LOG.info(monomer.getSmiles());
+				return -5400;
+			}
+		} catch (Exception e) {
+			LOG.info("SMILES could not be generated from Molfile");
+			return -5200;
+		}*/
+
+        if(monomer.getName().isEmpty() || monomer.getName() == null) {
+            Log.info("Monomer has no Name");
+            return -6000;
+        }
+        if(monomer.getPolymerType().isEmpty() || monomer.getPolymerType() == null) {
+            Log.info("Monomer has no Polymertype");
+            return -6100;
+        }
+        if(monomer.getSymbol().isEmpty() || monomer.getSymbol() == null) {
+            Log.info("Monomer has no Symbol");
+            return -6200;
+        }
+        if(monomer.getMonomerType().isEmpty() || monomer.getMonomerType() == null) {
+            Log.info("Monomer has no Monomertype");
+            return -6300;
+        }
+        if(monomer.getNaturalAnalog().isEmpty() || monomer.getNaturalAnalog() == null) {
+            Log.info("Monomer has no Natural Analog");
+            return -6400;
+        }
+        if(monomer.getCreateDate().isEmpty() || monomer.getCreateDate() == null) {
+            Date date = new Date();
+            monomer.setCreateDate(date.toString());
+            Log.info("Monomer has no CreateDate: current date is used");
+        }
+        if(monomer.getAuthor().isEmpty() || monomer.getAuthor() == null) {
+            Log.info("Monomer has no Author: Author is set to 'unknownAuthor'");
+            monomer.setAuthor("unknownAuthor");
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean checkRGroup(String smiles, List<Attachment> attachment) {
+        int numberGivenAttachment = attachment.size();
+        int numberAttachmentInSmiles = 0;
+
+        Pattern pattern = Pattern.compile("\\[\\*:([1-9]\\d*)\\]|\\[\\w+:([1-9]\\d*)\\]");
+        Matcher matcher = pattern.matcher(smiles);
+
+        while(matcher.find()) {
+            numberAttachmentInSmiles++;
+        }
+
+        if(numberAttachmentInSmiles == numberGivenAttachment)
+            return true;
+        else
+            return false;
+    }
+
+    @Override
+    public int checkRule(Rule rule) {
+        if(rule.getScript() == null || rule.getScript().isEmpty()) {
+            Log.info("Rule has no Script");
+            return -1000;
+        }
+
+        if(rule.getScript() == null || rule.getCategory().isEmpty()) {
+            Log.info("Rule has no category");
+            return -2000;
+        }
+
+        if(rule.getId() == null || rule.getId().toString().isEmpty()) {
+            Log.info("Rule has no ID");
+            return -3000;
+        }
+
+        if(rule.getAuthor() == null || rule.getAuthor().isEmpty()) {
+            rule.setAuthor("unknownAuthor");
+            Log.info("Rule has no Author; Author is set to 'unkownAuthor'");
+        }
+
+        if(rule.getDescription() == null || rule.getDescription().isEmpty()) {
+            rule.setDescription("no description");
+            Log.info("Rule has no description; Description is set to 'no description'");
+        }
+
+        return 0;
+    }
+}


### PR DESCRIPTION
Hi, 

I was working on internalizing this repo into Novartis' internal HELM services. I found that there was some duplicate code between the implementations of the IMonomerLibrary and the IRuleLibrary, specifically within private validation methods that checked Monomers and/or Rules. In this pull request, those are brought up and declared public in an "IValidation" interface, and implemented in a "Validation"  class. The implementation of the methods is directly taken from how they were implemented as private methods within the implementations of IMonomerLibrary and IRuleLibrary. This would just reduce some duplicate code and help anyone implementing the IMonomerLibrary and IRuleLibrary, by giving them access to these validation methods. 

Thanks,
Yash Bhalla 